### PR TITLE
fixed register new user

### DIFF
--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -126,7 +126,7 @@ class RetailCrmHistory
                     }
 
                     if ($registerNewUser === true) {
-                        $userPassword = uniqid();
+                        $userPassword = uniqid("R");
 
                         $arFields = array(
                             "EMAIL"             => $customer['email'],
@@ -137,7 +137,7 @@ class RetailCrmHistory
                         );
                         $registeredUserID = $newUser->Add($arFields);
                         if ($registeredUserID === false) {
-                            RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'CUser::Register', 'Error register user');
+                            RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'CUser::Register', 'Error register user: ' . $newUser->LAST_ERROR);
                             continue;
                         }
 
@@ -361,7 +361,7 @@ class RetailCrmHistory
                         }
 
                         if ($registerNewUser === true) {
-                            $userPassword = uniqid();
+                            $userPassword = uniqid("R");
 
                             $newUser = new CUser;
                             $arFields = array(
@@ -384,7 +384,7 @@ class RetailCrmHistory
                             $registeredUserID = $newUser->Add($arFields);
 
                             if ($registeredUserID === false) {
-                                RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'CUser::Register', 'Error register user');
+                                RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'CUser::Register', 'Error register user ' . $newUser->LAST_ERROR);
 
                                 continue;
                             }


### PR DESCRIPTION
1. Исправлена ошибка при которой не экспортировался заказ из retailCRM, если битрикс клиента  требовал заглавные латинские буквы в пароле, т.к. uniqid генерит только строчные.
2. Добавлен текст ошибки в случае неудачной регистрации пользователя.