### PR TITLE
Добавлены обработки ошибок при сохранении платежей.

### DIFF
--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -769,10 +769,10 @@ class RetailCrmHistory
                             if (array_key_exists($orderPayment->getField('XML_ID'), $newHistoryPayments)) {
                                 $paymentId = $orderPayment->getId();
                                 $paymentExternalId = RCrmActions::generatePaymentExternalId($paymentId);
-								if (is_null($paymentId)) {
-									RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'paymentsUpdate', 'Save payment error, order=' . $order['number']);
-									continue;
-								}
+                                if (is_null($paymentId)) {
+                                    RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'paymentsUpdate', 'Save payment error, order=' . $order['number']);
+                                    continue;
+                                }
                                 if ($paymentExternalId) {
                                     $newHistoryPayments[$orderPayment->getField('XML_ID')]['externalId'] = $paymentExternalId;
                                     RCrmActions::apiMethod($api, 'paymentEditById', __METHOD__, $newHistoryPayments[$orderPayment->getField('XML_ID')]);
@@ -1181,9 +1181,9 @@ class RetailCrmHistory
                 $newPaymentId = $newPayment->getId();
 
                 unset($paymentsList[$newPaymentId]);
-			} else {
-				RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'paymentsUpdate', 'Save payment error, incorrect type: '  . $paymentCrm['type']); 
-			}
+            } else {
+                RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'paymentsUpdate', 'Save payment error, incorrect type: '  . $paymentCrm['type']);
+            }
 
             if ($optionsPayment[$paymentCrm['status']] == 'Y') {
                 $paySumm += $paymentCrm['amount'];

--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -769,7 +769,10 @@ class RetailCrmHistory
                             if (array_key_exists($orderPayment->getField('XML_ID'), $newHistoryPayments)) {
                                 $paymentId = $orderPayment->getId();
                                 $paymentExternalId = RCrmActions::generatePaymentExternalId($paymentId);
-
+								if (is_null($paymentId)) {
+									RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'paymentsUpdate', 'Save payment error, order=' . $order['number']);
+									continue;
+								}
                                 if ($paymentExternalId) {
                                     $newHistoryPayments[$orderPayment->getField('XML_ID')]['externalId'] = $paymentExternalId;
                                     RCrmActions::apiMethod($api, 'paymentEditById', __METHOD__, $newHistoryPayments[$orderPayment->getField('XML_ID')]);
@@ -1161,7 +1164,7 @@ class RetailCrmHistory
 
                     unset($paymentsList[$nowPaymentId]);
                 }
-            } else {
+            } elseif (array_key_exists($paymentCrm['type'], $optionsPayTypes)) {
                 $newHistoryPayments[$paymentCrm['id']] = $paymentCrm;
                 $newPayment = $paymentColl->createItem();
                 $newPayment->setField('SUM', $paymentCrm['amount']);
@@ -1178,7 +1181,9 @@ class RetailCrmHistory
                 $newPaymentId = $newPayment->getId();
 
                 unset($paymentsList[$newPaymentId]);
-            }
+			} else {
+				RCrmActions::eventLog('RetailCrmHistory::orderHistory', 'paymentsUpdate', 'Save payment error, incorrect type: '  . $paymentCrm['type']); 
+			}
 
             if ($optionsPayment[$paymentCrm['status']] == 'Y') {
                 $paySumm += $paymentCrm['amount'];


### PR DESCRIPTION
- Добавлена обработка ошибки когда тип платежа установленный в retailCRM не имеет соответствия в Битрикс.
- Добавлена обработка ошибки когда не происходит сохранения платежа заказа.