### PR TITLE
Update RetailCrmHistory_v5.php

### DIFF
--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -714,7 +714,7 @@ class RetailCrmHistory
                                     if(!empty($order['delivery']['address'][$key])){
                                         $parameters = array();
                                         $locPoint = explode('.', $order['delivery']['address'][$key]);
-										$locComma = explode(',', $order['delivery']['address'][$key]);
+                                        $locComma = explode(',', $order['delivery']['address'][$key]);
                                         if (count($locPoint) == 1) {
                                             $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locPoint[0]));
                                         } elseif (count($locPoint) == 2) {

--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -719,11 +719,11 @@ class RetailCrmHistory
                                             $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locPoint[0]));
                                         } elseif (count($locPoint) == 2) {
                                             $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locPoint[1]));
-										} elseif (count($locComma) == 1){
-											$parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locComma[0]));
-										} elseif (count($locComma) == 2){
-											$parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locComma[1]));
-										}else {
+                                        } elseif (count($locComma) == 1){
+                                            $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locComma[0]));
+                                        } elseif (count($locComma) == 2){
+                                             $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locComma[1]));
+                                        } else {
                                             RCrmActions::eventLog(
                                                 'RetailCrmHistory::orderHistory',
                                                 'RetailCrmHistory::setProp',

--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -713,12 +713,17 @@ class RetailCrmHistory
                                     $order['delivery']['address'][$key] = trim($order['delivery']['address'][$key]);
                                     if(!empty($order['delivery']['address'][$key])){
                                         $parameters = array();
-                                        $loc = explode('.', $order['delivery']['address'][$key]);
-                                        if (count($loc) == 1) {
-                                            $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($loc[0]));
-                                        } elseif (count($loc) == 2) {
-                                            $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($loc[1]));
-                                        } else {
+                                        $locPoint = explode('.', $order['delivery']['address'][$key]);
+										$locComma = explode(',', $order['delivery']['address'][$key]);
+                                        if (count($locPoint) == 1) {
+                                            $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locPoint[0]));
+                                        } elseif (count($locPoint) == 2) {
+                                            $parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locPoint[1]));
+										} elseif (count($locComma) == 1){
+											$parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locComma[0]));
+										} elseif (count($locComma) == 2){
+											$parameters['filter']['PHRASE'] = RCrmActions::fromJSON(trim($locComma[1]));
+										}else {
                                             RCrmActions::eventLog(
                                                 'RetailCrmHistory::orderHistory',
                                                 'RetailCrmHistory::setProp',

--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -40,7 +40,7 @@ class RetailCrmService
                     unset($order['delivery']['data']);
                     break;
                 default:
-                    break;
+		            break;
             }
         }
         return $order;

--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -40,7 +40,7 @@ class RetailCrmService
                     unset($order['delivery']['data']);
                     break;
                 default:
-		            break;
+                    break;
             }
         }
         return $order;

--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -7,43 +7,42 @@ class RetailCrmService
         $deliveryCode = $order['delivery']['code'];
         if ($deliveryCode) {
             switch ($integrationDelivery[$deliveryCode]) {
-                 case "sdek":
+                case "sdek":
                     unset($order['number']);
                     unset($order['height']);
                     unset($order['length']);
                     unset($order['width']);
-					unset($order['weight']);
-            		unset($order['phone']);
-            		unset($order['delivery']['cost']);
-            		unset($order['shipmentStore']);
-            		unset($order['delivery']['address']);
-            		unset($order['delivery']['data']);
+                    unset($order['weight']);
+		    unset($order['phone']);
+                    unset($order['delivery']['cost']);
+                    unset($order['shipmentStore']);
+            	    unset($order['delivery']['address']);
+            	    unset($order['delivery']['data']);
                     break;
                 case "dpd":
                     unset($order['manager']);
                     unset($order['firstName']);
                     unset($order['lastName']);
-					unset($order['weight']);
-            		unset($order['phone']);
-            		unset($order['delivery']['cost']);
-            		unset($order['shipmentStore']);
-            		unset($order['delivery']['address']);
-            		unset($order['delivery']['data']);
+                    unset($order['weight']);
+		    unset($order['phone']);
+	            unset($order['delivery']['cost']);
+                    unset($order['shipmentStore']);
+                    unset($order['delivery']['address']);
+            	    unset($order['delivery']['data']);
                     break;
                 case "newpost":
                     unset($order['customer']);
-					unset($order['weight']);
-            		unset($order['phone']);
-            		unset($order['delivery']['cost']);
-            		unset($order['shipmentStore']);
-            		unset($order['delivery']['address']);
-            		unset($order['delivery']['data']);
+	            unset($order['weight']);
+            	    unset($order['phone']);
+            	    unset($order['delivery']['cost']);
+            	    unset($order['shipmentStore']);
+            	    unset($order['delivery']['address']);
+            	    unset($order['delivery']['data']);
                     break;
                 default:
-					break;
+		    break;
             }
         }
-
         return $order;
     }
 }

--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -7,31 +7,41 @@ class RetailCrmService
         $deliveryCode = $order['delivery']['code'];
         if ($deliveryCode) {
             switch ($integrationDelivery[$deliveryCode]) {
-                case "sdek":
+                 case "sdek":
                     unset($order['number']);
                     unset($order['height']);
                     unset($order['length']);
                     unset($order['width']);
+					unset($order['weight']);
+            		unset($order['phone']);
+            		unset($order['delivery']['cost']);
+            		unset($order['shipmentStore']);
+            		unset($order['delivery']['address']);
+            		unset($order['delivery']['data']);
                     break;
                 case "dpd":
                     unset($order['manager']);
                     unset($order['firstName']);
                     unset($order['lastName']);
+					unset($order['weight']);
+            		unset($order['phone']);
+            		unset($order['delivery']['cost']);
+            		unset($order['shipmentStore']);
+            		unset($order['delivery']['address']);
+            		unset($order['delivery']['data']);
                     break;
                 case "newpost":
                     unset($order['customer']);
+					unset($order['weight']);
+            		unset($order['phone']);
+            		unset($order['delivery']['cost']);
+            		unset($order['shipmentStore']);
+            		unset($order['delivery']['address']);
+            		unset($order['delivery']['data']);
                     break;
                 default:
-                    unset($order['firstName']);
-                    unset($order['lastName']);
+					break;
             }
-
-            unset($order['weight']);
-            unset($order['phone']);
-            unset($order['delivery']['cost']);
-            unset($order['shipmentStore']);
-            unset($order['delivery']['address']);
-            unset($order['delivery']['data']);
         }
 
         return $order;

--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -13,34 +13,34 @@ class RetailCrmService
                     unset($order['length']);
                     unset($order['width']);
                     unset($order['weight']);
-		    unset($order['phone']);
+                    unset($order['phone']);
                     unset($order['delivery']['cost']);
                     unset($order['shipmentStore']);
-            	    unset($order['delivery']['address']);
-            	    unset($order['delivery']['data']);
+                    unset($order['delivery']['address']);
+                    unset($order['delivery']['data']);
                     break;
                 case "dpd":
                     unset($order['manager']);
                     unset($order['firstName']);
                     unset($order['lastName']);
                     unset($order['weight']);
-		    unset($order['phone']);
-	            unset($order['delivery']['cost']);
+                    unset($order['phone']);
+                    unset($order['delivery']['cost']);
                     unset($order['shipmentStore']);
                     unset($order['delivery']['address']);
-            	    unset($order['delivery']['data']);
+                    unset($order['delivery']['data']);
                     break;
                 case "newpost":
                     unset($order['customer']);
-	            unset($order['weight']);
-            	    unset($order['phone']);
-            	    unset($order['delivery']['cost']);
-            	    unset($order['shipmentStore']);
-            	    unset($order['delivery']['address']);
-            	    unset($order['delivery']['data']);
+                    unset($order['weight']);
+                    unset($order['phone']);
+                    unset($order['delivery']['cost']);
+                    unset($order['shipmentStore']);
+                    unset($order['delivery']['address']);
+                    unset($order['delivery']['data']);
                     break;
                 default:
-		    break;
+		            break;
             }
         }
         return $order;


### PR DESCRIPTION
Добрый день. Обнаружил недочёт в модуле. Если в заказе, явно не задан индекс, модуль пытается получить локацию из адреса доставки. Однако, если адрес передаётся строкой с разделителем "," --запятая, получить индекс и соответственно вычислить локацию из такого адреса невозможно. Т.к. в коде модуля прописан explode исключительно в случае разделителя "." -- точка. Пример такого адреса: _143006, г. Одинцово, ул. Маяковского, д. 16_ . 