### PR TITLE
fix error during installation when orders count equals zero

### DIFF
--- a/intaro.retailcrm/install/index.php
+++ b/intaro.retailcrm/install/index.php
@@ -591,7 +591,12 @@ class intaro_retailcrm extends CModule
                 } else {
                     $finish = (int)$_POST['finish'];
                 }
-                $percent = round(100 - ($countLeft * 100 / $countAll), 1);
+
+                if (!$countAll) {
+                    $percent = 100;
+                } else {
+                    $percent = round(100 - ($countLeft * 100 / $countAll), 1);
+                }
 
                 if (!$countLeft) {
                     $finish = 1;


### PR DESCRIPTION
Возникла ошибка при установке модуля в систему, в которой нет заказав.
При установке $countAll = 0, и деление на ноль приводит к NaN, соответственно в $percent будет NaN.
Далее, при json_encode в строке https://github.com/retailcrm/bitrix-module/blob/master/intaro.retailcrm/install/index.php#L601 функция не срабатывает, возникает ошибка "Inf and NaN cannot be JSON encoded"

Из-за этого, при отсутствии заказов, не получается установить модуль, зависает на этапе экспорта заказов http://joxi.net/82QZEZ4uwGjkLA