### PR TITLE
FixRetailCrmService.php

### DIFF
--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -12,28 +12,37 @@ class RetailCrmService
                     unset($order['height']);
                     unset($order['length']);
                     unset($order['width']);
+                    unset($order['weight']);
+                    unset($order['phone']);
+                    unset($order['delivery']['cost']);
+                    unset($order['shipmentStore']);
+                    unset($order['delivery']['address']);
+                    unset($order['delivery']['data']);
                     break;
                 case "dpd":
                     unset($order['manager']);
                     unset($order['firstName']);
                     unset($order['lastName']);
+                    unset($order['weight']);
+                    unset($order['phone']);
+                    unset($order['delivery']['cost']);
+                    unset($order['shipmentStore']);
+                    unset($order['delivery']['address']);
+                    unset($order['delivery']['data']);
                     break;
                 case "newpost":
                     unset($order['customer']);
+                    unset($order['weight']);
+                    unset($order['phone']);
+                    unset($order['delivery']['cost']);
+                    unset($order['shipmentStore']);
+                    unset($order['delivery']['address']);
+                    unset($order['delivery']['data']);
                     break;
                 default:
-                    unset($order['firstName']);
-                    unset($order['lastName']);
+                    break;
             }
-
-            unset($order['weight']);
-            unset($order['phone']);
-            unset($order['delivery']['cost']);
-            unset($order['shipmentStore']);
-            unset($order['delivery']['address']);
-            unset($order['delivery']['data']);
         }
-
         return $order;
     }
 }

--- a/intaro.retailcrm/classes/general/services/RetailCrmService.php
+++ b/intaro.retailcrm/classes/general/services/RetailCrmService.php
@@ -39,6 +39,12 @@ class RetailCrmService
                     unset($order['delivery']['address']);
                     unset($order['delivery']['data']);
                     break;
+                case "boxberry":
+                    unset($order['firstName']);
+                    unset($order['lastName']);
+                    unset($order['delivery']['address']);
+                    unset($order['delivery']['cost']);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
Данный скрипт рассчитан на работу с интеграционными доставками, однако по defalt в коде используются unsent к некоторым полям заказа. Этот код отрабатывает и при выгрузке в CRM заказов по агенту из Битрикса. Затирается имя, фамилия, номер телефона и другие поля в информации о заказе.  Смоделировал ситуацию в собственной системе и подтвердил ошибку в логике работы этого класса.
Для того чтобы избежать эту ошибку, необходимо отказаться от параметров по defalt, для каждой интеграционной доставки, нужно определить поля которые нужно убрать. Реализовал это изменение, теперь данные приходят корректно.