### PR TITLE
FixOrderHistoryToBitrix

### DIFF
--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -690,7 +690,6 @@ class RetailCrmHistory
                         }
                     }
 
-
                     //optionsOrderProps
                     if ($optionsOrderProps[$personType]) {
                         foreach ($optionsOrderProps[$personType] as $key => $orderProp) {

--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -690,7 +690,6 @@ class RetailCrmHistory
                         }
                     }
 
-                    $order['fio'] = str_replace("clear", "", $order['fio']);
 
                     //optionsOrderProps
                     if ($optionsOrderProps[$personType]) {
@@ -1452,19 +1451,19 @@ class RetailCrmHistory
 
             if ($change['field'] == 'last_name') {
                 if (true == is_null($change['newValue'])) {
-                    $orders[$change['order']['id']]['lastName'] = 'clear';
+                    $orders[$change['order']['id']]['lastName'] = ' ';
                 }
             }
 
             if ($change['field'] == 'first_Name') {
                 if (true == is_null($change['newValue'])) {
-                    $orders[$change['order']['id']]['firstName'] = 'clear';
+                    $orders[$change['order']['id']]['firstName'] = ' ';
                 }
             }
 
             if ($change['field'] == 'patronymic') {
                 if (true == is_null($change['newValue'])) {
-                    $orders[$change['order']['id']]['patronymic'] = 'clear';
+                    $orders[$change['order']['id']]['patronymic'] = ' ';
                 }
             }
         }


### PR DESCRIPTION
Выявил недочёт в модуле. После удаления информации о клиенте в заказе (Фамилия, отчество или имя), и выгрузке истории на сайт, в битриксе затирается ФИО. При этом, достаточно удалить один параметр, допустим "отчество" в CRM, чтобы в CMS  пропали все три параметра в информации о заказе в битриксе. Дополнительно ситуация смоделирована и подтверждена на собственной системе.
Удалось исправить данный недочёт.