### PR TITLE
fix order save when corporate isn`t enabled and CRM_CC is undefined

### DIFF
--- a/intaro.retailcrm/classes/general/events/RetailCrmEvent.php
+++ b/intaro.retailcrm/classes/general/events/RetailCrmEvent.php
@@ -195,7 +195,7 @@ class RetailCrmEvent
 
         $orderCompany = null;
 
-        if ("Y" == $optionCorpClient && $optionsContragentType[$arOrder['PERSON_TYPE_ID']] == 'legal-entity') {
+        if ("Y" === $optionCorpClient && $optionsContragentType[$arOrder['PERSON_TYPE_ID']] == 'legal-entity') {
             //corparate cliente
             $nickName = '';
             $address = '';


### PR DESCRIPTION
После установки модуля, если настройки не обновлять, то в переменной $optionCorpClient будет int(0) . При не строгом сравнении со строкой вернет true.
В связи с этим возникают ситуации, когда корпоративные клиенты выключены, но при попытке оформить заказ как юр.лицо, модуль попытается выгрузить заказ как корпоративный.