### PR TITLE
Update config

### DIFF
--- a/intaro.retailcrm/classes/general/config/retailcrm.json
+++ b/intaro.retailcrm/classes/general/config/retailcrm.json
@@ -41,6 +41,15 @@
         "street": {
             "type": "string"
         },
+        "regionId":{
+            "type": "int"
+        },
+        "cityId":{
+            "type": "int"
+        },
+        "streetId":{
+            "type": "int"
+        },
         "building": {
             "type": "string"
         },
@@ -489,6 +498,15 @@
         },
         "street": {
             "type": "string"
+        },
+        "regionId":{
+            "type": "int"
+        },
+        "cityId":{
+            "type": "int"
+        },
+        "streetId":{
+            "type": "int"
         },
         "building": {
             "type": "string"


### PR DESCRIPTION
Заметил отсутствии в данном конфиге полей соответствующих идентификатору региона, города и улицы в GeoHelper. Данные поля есть в api, но из-за отсутствия их в конфиге, модуль их не передаёт. 