### PR TITLE
fix wiping 'fio' field if it is doesn`t present in history

### DIFF
--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -690,7 +690,9 @@ class RetailCrmHistory
                         }
                     }
 
-                    $order['fio'] = str_replace("clear", "", $order['fio']);
+                    if (array_key_exists('fio', $order)) {
+                        $order['fio'] = str_replace("clear", "", $order['fio']);
+                    }
 
                     //optionsOrderProps
                     if ($optionsOrderProps[$personType]) {


### PR DESCRIPTION
Предлагаю рассмотреть возможность следующей доработки:

В это место

https://github.com/retailcrm/bitrix-module/blob/v5.6.1/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php#L693

может прийти массив $order, у которого не будет ключа "fio", что приведет к тому что будет добавлен ключ с пустой строкой.

Предлагаю добавить проверку на существование ключа, что поможет избежать следующей ошибки:

Создается заказ в Битрикс с ФИО в поле заказа, затем он выгружается в CRM.
В CRM, в заказе, изменяется любая информации, кроме ФИО. Заказ выгружается в Битрикс.
На этом этапе заказ выглядит, примерно, так:
```
Array
        (
            [id] => 86786
            [externalId] => 86200
            [site] => xxx-ru
            [status] => new
        )
```

После указанной выше строки он становится таким:
```
Array
        (
            [id] => 86786
            [externalId] => 86200
            [site] => xxx-ru
            [status] => new
            [fio] => 
        )
```

Это приводит к тому, что логика модуля очистит данное поле в заказе в Битрикс:

http://joxi.net/4AkyayEuopVwRm

http://joxi.net/Dr8djd9uoaDOYr