### PR TITLE
Inventories upload fix

### DIFF
--- a/intaro.retailcrm/classes/general/inventories/RetailCrmInventories.php
+++ b/intaro.retailcrm/classes/general/inventories/RetailCrmInventories.php
@@ -84,8 +84,8 @@ class RetailCrmInventories
                     }
 
                     $elems = array();
-                    $chunkStores = array_chunk($stores, 50, true);
-                    foreach ($chunkStores as $stores) { 
+                    $storesChunks = array_chunk($stores, 50, true);
+                    foreach ($storesChunks as $storesChunk) {
                         foreach ($products as $product) {
                             if (count($product['offers']) > 0) {
                                 $elems = array_merge($elems, $product['offers']);
@@ -97,7 +97,7 @@ class RetailCrmInventories
                         $invUpload = array();
                         $dbStoreProduct = CCatalogStoreProduct::GetList(
                             array(),
-                            array('PRODUCT_ID' => $elems, 'STORE_ID' => array_keys($stores)),
+                            array('PRODUCT_ID' => $elems, 'STORE_ID' => array_keys($storesChunk)),
                             false,
                             false,
                             array('PRODUCT_ID', 'STORE_ID', 'AMOUNT')
@@ -109,8 +109,8 @@ class RetailCrmInventories
                                 );
                             }
                             $invUpload[$arStoreProduct['PRODUCT_ID']]['stores'][] = array(
-                                'code' => $stores[$arStoreProduct['STORE_ID']],
-                                'available' => self::switchCount($arStoreProduct['AMOUNT'], $inventoriesType[$stores[$arStoreProduct['STORE_ID']]]),
+                                'code' => $storesChunk[$arStoreProduct['STORE_ID']],
+                                'available' => self::switchCount($arStoreProduct['AMOUNT'], $inventoriesType[$storesChunk[$arStoreProduct['STORE_ID']]]),
                             );
                         }    
                         //for log                  


### PR DESCRIPTION
Есть предложение внести следующую корректировку:

Переименовать локальную переменную `$stores`, используемую в цикле `foreach`.

При выгрузке остатков, в начале скрипта, склады записываются в переменную `$stores`. 
https://github.com/retailcrm/bitrix-module/blob/master/intaro.retailcrm/classes/general/inventories/RetailCrmInventories.php#L27
Эта переменная используется в нескольких вложенных циклах.
В цикле `foreach` есть локальная переменная с таким же названием, которая перезаписывает исходное значение.

Это приводит к тому, что в данном месте
https://github.com/retailcrm/bitrix-module/blob/master/intaro.retailcrm/classes/general/inventories/RetailCrmInventories.php#L87
, при первом проходе вышестоящего цикла `do while`, массив из переменной `$stores` разбивается на "чанки" по 50шт, а при последующих проходах используется последние значение `$stores` после цикла `foreach`.

Данное поведение было обнаружено при попытке выгрузить остатки при наличии в Битрикс >100 складов и >100к товаров.

Также предлагается переименовать переменную `$chunkStores` в `$storesChunks`, чтобы было понятнее конструкция `foreach ($storesChunks as $storesChunk)`.

