### PR TITLE
fix catalog re-generation

### DIFF
--- a/intaro.retailcrm/lib/icml/icmldirector.php
+++ b/intaro.retailcrm/lib/icml/icmldirector.php
@@ -92,6 +92,7 @@ class IcmlDirector
      */
     public function generateXml(): void
     {
+        unlink($this->setup->filePath);
         $this->setXmlData();
         $this->icmlWriter->writeToXmlTop($this->xmlData);
         $this->logger->write(


### PR DESCRIPTION
При повторной генерации каталога файл не очищается, в итоге содержимое каталога добавляется второй/третий/т.д. раз и каталог становится нерабочим. Добавлено удаление файла каталога перед его генерацией.