### PR TITLE
Changed options for prices and corps

### DIFF
--- a/intaro.retailcrm/options.php
+++ b/intaro.retailcrm/options.php
@@ -438,7 +438,7 @@ if (isset($_POST['Update']) && ($_POST['Update'] === 'Y')) {
             return preg_match("/^shops-price/", $var);
         }
 
-        $bitrixPriceShopsArr = str_replace('shops-price-', '', array_filter(array_keys($_POST), 'maskPrice'));
+        $bitrixPriceShopsArr = array_values(array_filter($_POST, 'maskPrice', ARRAY_FILTER_USE_KEY));
         $arResult['bitrixIblocksExportList'] = RCrmActions::IblocksExportList();
 
         foreach ($arResult['bitrixIblocksExportList'] as $bitrixIblocks) {
@@ -516,7 +516,7 @@ if (isset($_POST['Update']) && ($_POST['Update'] === 'Y')) {
             return preg_match("/^shops-corporate/", $var);
         }
 
-        $bitrixCorpShopsArr = str_replace('shops-corporate-', '', array_filter(array_keys($_POST), 'maskCorp'));
+        $bitrixCorpShopsArr = array_values(array_filter($_POST, 'maskCorp', ARRAY_FILTER_USE_KEY));
 
         RegisterModuleDependences("main", "OnBeforeProlog", $mid, "RetailCrmCc", "add");
     } else {
@@ -2202,7 +2202,7 @@ if (isset($_POST['Update']) && ($_POST['Update'] === 'Y')) {
                 echo 'style="display: none;"';
             } ?>>
                 <td colspan="2" class="option-other-center">
-                    <label><input class="addr" type="checkbox" name="shops-price-<? echo $sitesList['code']; ?>" value="Y" <?php if (in_array($sitesList['code'], $optionPriceShops)) {
+                    <label><input class="addr" type="checkbox" name="shops-price-<? echo $sitesList['code']; ?>" value="<? echo $sitesList['code']; ?>" <?php if (in_array($sitesList['code'], $optionPriceShops)) {
                             echo "checked";
                         } ?>> <?php echo $sitesList['name'] . ' (' . $sitesList['code'] . ')'; ?></label>
                 </td>
@@ -2390,7 +2390,7 @@ if (isset($_POST['Update']) && ($_POST['Update'] === 'Y')) {
                 <td width="50%" class="" name="<?php ?>" align="center">
                     <?php foreach ($arResult['sitesList'] as $sitesList): ?>
                 <td colspan="2" class="option-other-center">
-                    <label><input class="addr" type="checkbox" name="shops-corporate-<? echo $sitesList['code']; ?>" value="Y" <?php if (in_array($sitesList['code'], $optionCorpShops)) {
+                    <label><input class="addr" type="checkbox" name="shops-corporate-<? echo $sitesList['code']; ?>" value="<? echo $sitesList['code']; ?>" <?php if (in_array($sitesList['code'], $optionCorpShops)) {
                             echo "checked";
                         } ?>> <?php echo $sitesList['name'] . ' (' . $sitesList['code'] . ')'; ?></label>
                 </td>


### PR DESCRIPTION
Был замечен кейс, где в символьном коде магазина присутствовал символ точка ("."), что сломало настройки магазина для корп-клиентов. Из-за строения настроек модуля (это форма, а настройка магазина в корпах - галочка) сломалось отображение настройки, несмотря на то, что магазин ранее был выбран и уже присутствовал в таблицах, в настройках модуля это не отображалось. Заодно поправил и аналогичную настройку для типов цен, так как она работает по тому же принципу.