### PR TITLE
Исправление редактирования свойств заказа в 1С Битрикс

### DIFF
--- a/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
+++ b/intaro.retailcrm/classes/general/history/RetailCrmHistory_v5.php
@@ -1863,7 +1863,7 @@ class RetailCrmHistory
         if (!isset($obj) || empty($obj)) {
             return false;
         }
-        if ($prop && $value) {
+        if ($prop && $value || $prop && !$value) {
             $obj->setField($prop, $value);
         } elseif ($value && !$prop) {
             $obj->setValue($value);


### PR DESCRIPTION
К примеру заказ создался на сайте (в заказе был заполнен комментарий), заказ передался в црм. В црм удалили комментарий, модуль подтянул на сайт изменения из истории црм, комментарий в заказе на сайте остался без изменения (хотя должен был удалиться). Данный фикс исправит выше описанную ситуацию.