### PR TITLE
empty product properties fix

### DIFF
--- a/intaro.retailcrm/lib/icml/settingsservice.php
+++ b/intaro.retailcrm/lib/icml/settingsservice.php
@@ -585,9 +585,9 @@ class SettingsService
     /**
      * @param int $iblockId
      *
-     * @return array
+     * @return array|null
      */
-    public function getProductProps(int $iblockId): array
+    public function getProductProps(int $iblockId): ?array
     {
         $propertiesProduct = null;
 


### PR DESCRIPTION
При редактировании профиля экспорта каталога, если в каталоге товаров есть товар без свойств, то функция `getProductProps` падала с ошибкой типизации получая `null` при ожидаемом `array`. По аналогии с `getSkuProps` приведена к возвращаемому `nullable` значению.