### PR TITLE
Fixed loyalty program rewrite in order

### DIFF
--- a/intaro.retailcrm/lib/service/loyaltyaccountservice.php
+++ b/intaro.retailcrm/lib/service/loyaltyaccountservice.php
@@ -253,7 +253,9 @@ class LoyaltyAccountService
         $file = 'loyaltyStatus';
         $privilegeType = 'none';
 
-        if (isset($arParams['crmOrder']['privilegeType'])) {
+        if (!empty($arParams['customerCorporate']['privilegeType'])) {
+            $privilegeType = $arParams['crmOrder']['privilegeType'];
+        } else if (isset($arParams['crmOrder']['privilegeType'])) {
             return $arParams['crmOrder']['privilegeType'];
         } elseif (ConfigProvider::getLoyaltyProgramStatus() === 'Y' && self::getLoyaltyPersonalStatus()) {
             $privilegeType = 'loyalty_level';

--- a/intaro.retailcrm/lib/service/loyaltyaccountservice.php
+++ b/intaro.retailcrm/lib/service/loyaltyaccountservice.php
@@ -253,8 +253,8 @@ class LoyaltyAccountService
         $file = 'loyaltyStatus';
         $privilegeType = 'none';
 
-        if (!empty($arParams['customerCorporate']['privilegeType'])) {
-            $privilegeType = $arParams['crmOrder']['privilegeType'];
+        if (isset($arParams['crmOrder']['privilegeType'])) {
+            return $arParams['crmOrder']['privilegeType'];
         } elseif (ConfigProvider::getLoyaltyProgramStatus() === 'Y' && self::getLoyaltyPersonalStatus()) {
             $privilegeType = 'loyalty_level';
         }


### PR DESCRIPTION
Игнорируем данные из битрикса, если в заказе указана программа лояльности.

Суть заключается в том, что при оформлении заказа система получает информацию о программе лояльности от текущего залогиненного пользователя.
Т.е. пользователь сделал заказ (используется его программа лояльности), а когда администратор обновляет заказ в админ панели уже используется инормация о программе лояльности самого администратора, а не того пользователя, чей заказ был отредактирован.

Фикс не обрабатывает вариант при котором админ руками в админке создает заказ. Тогда будут тянуться данные программы лояльности от админа, а не от целевого пользователя.
